### PR TITLE
fix typing on swiper

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -336,7 +336,7 @@ export interface SwiperProps {
 /**
  * Swiper component
  */
-export class Swiper extends React.Component<SwiperProps, any> {
+export default class Swiper extends React.Component<SwiperProps, any> {
     /**
      * Go to next slide
      */


### PR DESCRIPTION
Swiper was exported as default 
<img width="350" alt="Screen Shot 2019-09-19 at 1 08 52 PM" src="https://user-images.githubusercontent.com/25707872/65217599-bd000200-dade-11e9-9a4c-2b5c1c24a6be.png">
but in the typing it's not exported as default, therefore TS complain
<img width="555" alt="Screen Shot 2019-09-19 at 1 10 34 PM" src="https://user-images.githubusercontent.com/25707872/65217659-e6b92900-dade-11e9-96e2-18cd18b4ff37.png">

