### PR TITLE
Remove redefinition of StyleProp

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,6 @@ type Falsy = undefined | null | false;
 interface RecursiveArray<T> extends Array<T | RecursiveArray<T>> {}
 /** Keep a brand of 'T' so that calls to `StyleSheet.flatten` can take `RegisteredStyle<T>` and return `T`. */
 type RegisteredStyle<T> = number & { __registeredStyleBrand: T };
-export type StyleProp<T> = T | RegisteredStyle<T> | RecursiveArray<T | RegisteredStyle<T> | Falsy> | Falsy;
 
 export type SwiperControlsCorners =
     | 'top-left'


### PR DESCRIPTION
Running `tsc` on my project resulted in the following error:

```
node_modules/react-native-web-swiper/index.d.ts:5:5 - error TS2440: Import declaration conflicts with local declaration of 'StyleProp'.

5     StyleProp,
      ~~~~~~~~~
```

`StyleProp` is already imported from `'react-native'`. This removes the re-definition of `StyleProp`.