### PR TITLE
Update how children are rendered to prevent state loss

### DIFF
--- a/src/Swiper.js
+++ b/src/Swiper.js
@@ -7,8 +7,7 @@ import DefaultControls from './Controls';
 const useNativeDriver = false; // because of RN #13377
 
 class Swiper extends React.Component {
-  children = (() => React.Children.toArray(this.props.children))();
-  count = (() => this.children.length)();
+  count = (() => React.Children.toArray(this.props.children).length)();
 
   startAutoplay() {
     const { timeout } = this.props;
@@ -234,6 +233,7 @@ class Swiper extends React.Component {
       controlsEnabled,
       controlsProps,
       Controls = DefaultControls,
+      children,
     } = this.props;
 
     return (
@@ -257,7 +257,7 @@ class Swiper extends React.Component {
             ])}
             {...this._panResponder.panHandlers}
           >
-            {this.children.map((el, i) => (
+            {children.map((el, i) => (
               <View
                 key={i}
                 style={StyleSheet.flatten([


### PR DESCRIPTION
## The issue
`children = (() => React.Children.toArray(this.props.children))();`
The use of an anonymous function here for rendering the children effectively creates new components on every rerender of the parent. This creates an issue for example when you have a `TextInput` in one of the children with a hoisted state, for every character you write new components are created and all state is lost.

## The Fix
This fix just takes the `children` from the props and renders it, which fixes this issue.

## My temporary workaround
The workaround I am using at the moment is a somewhat not-so-pretty monkey patch:
````
 React.useEffect(() => {
    const childrenArray = React.Children.toArray(
      swiperRef.current?.props?.children
    );
    if (swiperRef.current) {
      swiperRef.current.children = childrenArray;
      swiperRef.current.count = childrenArray.length;
      swiperRef.current.forceUpdate();
    }
  }, [children]);
````
Where `children` is a variable holding the children I render inside the `Swiper`.